### PR TITLE
Add support for valgrind outputs filtered by CTest/CDash

### DIFF
--- a/plugin/valgrind.vim
+++ b/plugin/valgrind.vim
@@ -40,6 +40,12 @@
 " g:dont_export_hotkeys
 "    Don't remap <C-k> and <C-j> to navigate the call stack
 "
+" g:valgrind_file_process_hook
+"    Sometimes vagrind outputs are post-processed by other tools like CTest
+"    that add leading characters like "42: ". Define this action to execute on
+"    the current buffer to restore valgrind output. For CTest, it would be:
+"       :let g:valgrind_file_process_hook = '%s/\v^\d\+: //'
+"
 " Example:
 "
 " If you want valgrind to always do leak checking, put the following into your
@@ -123,8 +129,11 @@ function! s:Valgrind( ... )
     else
         silent execute 'split '.l:tmpfile
     endif
-    silent execute 'g!/^\(\d\+: \)\===\d*==/d'
-    silent execute '%s/^\(\d\+: \)\===\d*== //e'
+    if exists('g:valgrind_file_process_hook')
+      silent execute g:valgrind_file_process_hook
+    endif
+    silent execute 'g!/^==\d*==/d'
+    silent execute '%s/^==\d*== //e'
     silent execute '1'
 
     " Keep the valgrind buffer for future use

--- a/plugin/valgrind.vim
+++ b/plugin/valgrind.vim
@@ -88,7 +88,7 @@ endif
 "--------------------------------------------
 " Valgrind( filename ) {{{
 
-function s:Valgrind( ... )
+function! s:Valgrind( ... )
     let l:tmpfile=tempname()
 
     " construct the commandline and execute it
@@ -184,7 +184,7 @@ endfunction
 " }}}
 " Find_File( filename ) {{{
 
-function s:Find_File( filename )
+function! s:Find_File( filename )
     if filereadable( a:filename )
     return a:filename
     else
@@ -196,7 +196,7 @@ endfunction
 " }}}
 " Jump_To_Error( new_window, stay_valgrind_window ) {{{
 
-function s:Jump_To_Error(new_window, stay_valgrind_window )
+function! s:Jump_To_Error(new_window, stay_valgrind_window )
     " do not process empty lines
     let l:curline = getline('.')
     if l:curline == ''
@@ -211,7 +211,7 @@ function s:Jump_To_Error(new_window, stay_valgrind_window )
 
 endfunction
 
-function s:OpenStackTraceLine(new_window, no_new_window, stackLine ) 
+function! s:OpenStackTraceLine(new_window, no_new_window, stackLine )
     " What does it mean to say "no new window?" 
     let l:stay_this_window = a:no_new_window
     let l:stay_valgrind_window = 0
@@ -318,7 +318,7 @@ function s:OpenStackTraceLine(new_window, no_new_window, stackLine )
 
 endfunction
 
-function s:Up()
+function! s:Up()
     let s:lineNo = s:lineNo + 1
     let l:stackLine = getbufline(s:val_buffer,s:lineNo)
     if s:OpenStackTraceLine(0, 1, l:stackLine[0]) == -1
@@ -327,7 +327,7 @@ function s:Up()
     endif
 endfunction
 
-function s:Down()
+function! s:Down()
     let s:lineNo = s:lineNo - 1
     let l:stackLine = getbufline(s:val_buffer,s:lineNo)
     if s:OpenStackTraceLine(0, 1, l:stackLine[0]) == -1
@@ -339,7 +339,7 @@ endfunction
 " }}}
 " Zoom_Window() {{{
 
-function s:Zoom_Window()
+function! s:Zoom_Window()
     if !exists("s:win_maximized")
     let s:win_maximized = 0
     endif
@@ -363,7 +363,7 @@ endfunction
 " }}}
 " Show_Help( first_time ) {{{
 
-function s:Show_Help( first_time )
+function! s:Show_Help( first_time )
     setl modifiable
 
     if !a:first_time

--- a/plugin/valgrind.vim
+++ b/plugin/valgrind.vim
@@ -123,8 +123,8 @@ function! s:Valgrind( ... )
     else
         silent execute 'split '.l:tmpfile
     endif
-    silent execute 'g!/^==\d*==/d'
-    silent execute '%s/^==\d*== //e'
+    silent execute 'g!/^\(\d\+: \)\===\d*==/d'
+    silent execute '%s/^\(\d\+: \)\===\d*== //e'
     silent execute '1'
 
     " Keep the valgrind buffer for future use
@@ -212,10 +212,10 @@ function! s:Jump_To_Error(new_window, stay_valgrind_window )
 endfunction
 
 function! s:OpenStackTraceLine(new_window, no_new_window, stackLine )
-    " What does it mean to say "no new window?" 
+    " What does it mean to say "no new window?"
     let l:stay_this_window = a:no_new_window
     let l:stay_valgrind_window = 0
-    if l:stay_this_window && winnr() == s:val_winnum 
+    if l:stay_this_window && winnr() == s:val_winnum
         let l:stay_valgrind_window = 1
         let l:stay_this_window = 0
     endif
@@ -234,7 +234,7 @@ function! s:OpenStackTraceLine(new_window, no_new_window, stackLine )
     " determine file and line to go to
     let l:curline = substitute( substitute( a:stackLine, '.*(', '', '' ), ').*', '', '' )
     let l:filename = s:Find_File( substitute( l:curline, ':\d*$', '', '' ) )
-    if l:filename == "" 
+    if l:filename == ""
         return 1
     endif
     let l:linenumber = substitute( l:curline, '.*:', '', '' )
@@ -250,7 +250,7 @@ function! s:OpenStackTraceLine(new_window, no_new_window, stackLine )
     let l:winnum = bufwinnr( l:bufnum )
     if l:bufnum == -1 || l:winnum == -1
         "first find or create a suitable window
-        if l:stay_this_window 
+        if l:stay_this_window
             let l:this_win = winnr()
             execute l:this_win.'wincmd w'
         else

--- a/plugin/valgrind.vim
+++ b/plugin/valgrind.vim
@@ -1,6 +1,8 @@
 " Vim global plugin for valgrind
-" Maintainer: Rainer M. Schmid <rms@trolltech.com>
-" Version: $Id: valgrind.vim,v 1.2 2003/03/31 08:43:27 rms Exp $
+" Initial author: Rainer M. Schmid <rms@trolltech.com>
+" Maintainer: Luke Humphreys
+" Contribution: Luc Hermitte 2017, CMake support
+" Version: forked from v1.2
 
 
 " General:


### PR DESCRIPTION
This is a first PR.

 I'll eventually have other(s?) that move the functions to autoload plugins, and that provide options to chose the keybindings (a mapping on `<space>` with this new trend to set the leader to `<space>` can be problematic).